### PR TITLE
fix docker-compose error: configs.qdrant_config

### DIFF
--- a/docker/llmware/llmware_qdrant/docker-compose.yaml
+++ b/docker/llmware/llmware_qdrant/docker-compose.yaml
@@ -24,19 +24,12 @@ services:
       - 6333
       - 6334
       - 6335
-    configs:
-      - source: qdrant_config
-        target: /qdrant/config/production.yaml
     volumes:
       - qdrant_data:/qdrant_data
+      - ./qdrant_config.yaml:/qdrant/config/production.yaml
 
 volumes:
   llmware-mongodb:
     driver: local
   qdrant_data:
     driver: local
-
-configs:
-  qdrant_config:
-    content: |
-      log_level: INFO

--- a/docker/llmware/llmware_qdrant/qdrant_config.yaml
+++ b/docker/llmware/llmware_qdrant/qdrant_config.yaml
@@ -1,0 +1,1 @@
+log_level: INFO


### PR DESCRIPTION
While running the `docker-compose up -d` on MacOs the following error is thrown: 
```
configs.qdrant_config Additional property content is not allowed
```

This is because the `docker-compose.yaml` is using a `configs` section, which is not a standard Docker Compose feature. 
Instead of the ﻿`configs` section, we can use the ﻿`volumes` directive in Docker Compose to mount a file from the host into the container. If we have a configuration file on your host machine, we can mount it into the container at the desired location. 

The purpose of this pull request is to fix this issue.

--- 
Btw, thanks for the cool project.  I think it has great potential.