### PR TITLE
Update globals.py to include "sail_running = False"

### DIFF
--- a/llama_index_pq/pq/globals.py
+++ b/llama_index_pq/pq/globals.py
@@ -2,6 +2,7 @@ import threading
 
 class _globals_store:
     globals_store = None
+    sail_running = False
 
     def __init__(self):
         if _globals_store.globals_store == None:


### PR DESCRIPTION
I was encountering an error when running a new Sail where it wouldn't save my changes to the sailing configs to settings.dat and was "stuck" using the initially set values. 

From what I could tell this variable was just straight missing from the file? Adding it in and defaulting it to False like this seems to have resolved the issue.