### PR TITLE
Update start_prompt_quill_docker.bat

### DIFF
--- a/llama_index_pq/start_prompt_quill_docker.bat
+++ b/llama_index_pq/start_prompt_quill_docker.bat
@@ -16,7 +16,7 @@ call "%CONDA_ROOT_PREFIX%\condabin\conda.bat" activate "%INSTALL_ENV_DIR%" || ( 
 
 start /W "" python pq/check_qdrant_up.py
 
-call python prompt_quill_ui_qdrant.py
+call python pq/prompt_quill_ui_qdrant.py
 
 
 pause


### PR DESCRIPTION
Changed pointer to start file and avoid `file not found` error assuming the user is clicking on this file. Python doesn't know it resides in the `pq` folder.